### PR TITLE
chore(security): repo-level hardening — PR CI, pinned actions, SRI, lockdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+# Default GITHUB_TOKEN scope is read-only; each job opts into the writes it needs.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -18,20 +17,25 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Install, build, and upload site
-        uses: withastro/action@v5
+        uses: withastro/action@15aa0a5a1e067940253e3b259413ab2ae882a740 # v5.0.0
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,51 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+# Read-only token. PR checks should never write to the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-check-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: Enable corepack (provides pnpm)
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Audit production deps
+        run: pnpm audit --prod --audit-level=high
+        continue-on-error: true

--- a/src/components/blog/Pseudocode.tsx
+++ b/src/components/blog/Pseudocode.tsx
@@ -20,11 +20,13 @@ export function Pseudocode({ code, caption }: PseudocodeProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Load pseudocode.js CSS
+    // Load pseudocode.js CSS — integrity hash locks the file against CDN tampering
     if (!document.querySelector('link[href*="pseudocode"]')) {
       const cssLink = document.createElement('link');
       cssLink.rel = 'stylesheet';
       cssLink.href = 'https://cdn.jsdelivr.net/npm/pseudocode@2.4.1/build/pseudocode.min.css';
+      cssLink.integrity = 'sha384-ff9LEHNvuDqxJT/JRjAeQ1cWTWambRLe5j49SnOzhaotb23KEQkCanV+ooL+ch4k';
+      cssLink.crossOrigin = 'anonymous';
       document.head.appendChild(cssLink);
     }
 
@@ -38,6 +40,9 @@ export function Pseudocode({ code, caption }: PseudocodeProps) {
 
         const katexScript = document.createElement('script');
         katexScript.src = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js';
+        katexScript.integrity =
+          'sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8';
+        katexScript.crossOrigin = 'anonymous';
         katexScript.onload = () => resolve();
         katexScript.onerror = () => reject(new Error('Failed to load KaTeX'));
         document.head.appendChild(katexScript);
@@ -54,6 +59,9 @@ export function Pseudocode({ code, caption }: PseudocodeProps) {
 
         const script = document.createElement('script');
         script.src = 'https://cdn.jsdelivr.net/npm/pseudocode@2.4.1/build/pseudocode.min.js';
+        script.integrity =
+          'sha384-i3+YbLfC66kxqBVtgH6I+lEFAr+57mVZY/MSthCK/oTPo0rWCRzW/kSg2mJnTKLs';
+        script.crossOrigin = 'anonymous';
         script.onload = () => resolve();
         script.onerror = () => reject(new Error('Failed to load pseudocode.js'));
         document.head.appendChild(script);


### PR DESCRIPTION
Adds a defensive baseline against fork-PR-based supply-chain attacks and CDN tampering: a new `.github/workflows/pr-check.yml` runs `pnpm typecheck`/`lint`/`format:check`/`build`/`audit` on every PR (so a broken commit can't reach `master` via merge); both workflows now pin every action to a commit SHA (`actions/checkout`, `withastro/action`, `actions/deploy-pages`, `actions/setup-node`) so a maintainer-account compromise or tag rewrite can't swap in malicious code; `ci.yml` drops the default `pages: write`/`id-token: write` permissions down to per-job scope; and the three jsdelivr-loaded scripts in `Pseudocode.tsx` (pseudocode CSS, KaTeX JS, pseudocode JS) now ship `integrity` SHA-384 hashes plus `crossOrigin="anonymous"`, so a CDN compromise can't substitute the files. Repo settings (applied directly via `gh api`, not part of this diff) — secret scanning + push protection enabled, `delete_branch_on_merge` enabled, default GITHUB_TOKEN scope now read-only, workflow PR-review-approval disabled, SHA pinning required for all action references. Branch protection on `master` requiring this PR check + linear history will be applied right after merge (the status check has to exist on the default branch first).